### PR TITLE
설문 작성 페이지 내의 입력 컴포넌트 구현

### DIFF
--- a/src/components/SurveyTextArea.tsx
+++ b/src/components/SurveyTextArea.tsx
@@ -16,9 +16,13 @@ const Container = styled(TextareaAutosize)`
 `;
 
 interface Props {
+  placeholder: string;
   defaultValue: string;
 }
 
-export default function SurveyTextArea({ defaultValue }: Props): JSX.Element {
-  return <Container defaultValue={defaultValue} />;
+export default function SurveyTextArea({
+  placeholder = '',
+  defaultValue = '',
+}: Props): JSX.Element {
+  return <Container placeholder={placeholder} defaultValue={defaultValue} />;
 }

--- a/src/components/SurveyTextArea.tsx
+++ b/src/components/SurveyTextArea.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { TextareaAutosize } from '@material-ui/core';
+
+export default function SurveyTextArea(): JSX.Element {
+  return <TextareaAutosize />;
+}

--- a/src/components/SurveyTextArea.tsx
+++ b/src/components/SurveyTextArea.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import styled from 'styled-components';
 import { TextareaAutosize } from '@material-ui/core';
 
+interface Props {
+  placeholder?: string;
+  defaultValue?: string;
+}
+
 const Container = styled(TextareaAutosize)`
   width: 100%;
   border: none;
@@ -14,11 +19,6 @@ const Container = styled(TextareaAutosize)`
     border-bottom: 2px solid #673ab7;
   }
 `;
-
-interface Props {
-  placeholder?: string;
-  defaultValue?: string;
-}
 
 export default function SurveyTextArea({
   placeholder = '',

--- a/src/components/SurveyTextArea.tsx
+++ b/src/components/SurveyTextArea.tsx
@@ -15,6 +15,10 @@ const Container = styled(TextareaAutosize)`
   }
 `;
 
-export default function SurveyTextArea(): JSX.Element {
-  return <Container />;
+interface Props {
+  defaultValue: string;
+}
+
+export default function SurveyTextArea({ defaultValue }: Props): JSX.Element {
+  return <Container defaultValue={defaultValue} />;
 }

--- a/src/components/SurveyTextArea.tsx
+++ b/src/components/SurveyTextArea.tsx
@@ -1,6 +1,20 @@
 import React from 'react';
+import styled from 'styled-components';
 import { TextareaAutosize } from '@material-ui/core';
 
+const Container = styled(TextareaAutosize)`
+  width: 100%;
+  border: none;
+  border-bottom: solid 2px #e0e0e0;
+  outline: none;
+  resize: none;
+  transition: border-bottom ease-out 0.5s;
+
+  &:focus {
+    border-bottom: 2px solid #673ab7;
+  }
+`;
+
 export default function SurveyTextArea(): JSX.Element {
-  return <TextareaAutosize />;
+  return <Container />;
 }

--- a/src/components/SurveyTextArea.tsx
+++ b/src/components/SurveyTextArea.tsx
@@ -16,8 +16,8 @@ const Container = styled(TextareaAutosize)`
 `;
 
 interface Props {
-  placeholder: string;
-  defaultValue: string;
+  placeholder?: string;
+  defaultValue?: string;
 }
 
 export default function SurveyTextArea({

--- a/src/components/SurveyTextArea.tsx
+++ b/src/components/SurveyTextArea.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { TextareaAutosize } from '@material-ui/core';
 
 interface Props {
   placeholder?: string;
   defaultValue?: string;
+  linebreak?: boolean;
 }
 
 const Container = styled(TextareaAutosize)`
@@ -23,6 +24,34 @@ const Container = styled(TextareaAutosize)`
 export default function SurveyTextArea({
   placeholder = '',
   defaultValue = '',
+  linebreak = true,
 }: Props): JSX.Element {
-  return <Container placeholder={placeholder} defaultValue={defaultValue} />;
+  const [value, setValue] = useState<string>(defaultValue);
+
+  const onKeyPress = (
+    event: React.KeyboardEvent<HTMLTextAreaElement>
+  ): void => {
+    if (event.key !== 'Enter' || linebreak) {
+      return;
+    }
+    event.preventDefault();
+  };
+
+  const onChange = ({
+    target,
+  }: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    const newValue = linebreak
+      ? target.value
+      : target.value.replace(/(\r\n|\n|\r)/gm, '');
+    setValue(newValue);
+  };
+
+  return (
+    <Container
+      value={value}
+      placeholder={placeholder}
+      onChange={onChange}
+      onKeyPress={onKeyPress}
+    />
+  );
 }

--- a/src/stories/SurveyTextArea.stories.tsx
+++ b/src/stories/SurveyTextArea.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import SurveyTextArea from '../components/SurveyTextArea';
+
+export default {
+  title: 'SurveyTextArea',
+  component: SurveyTextArea,
+};
+
+const Template = (args) => <SurveyTextArea {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/stories/SurveyTextArea.stories.tsx
+++ b/src/stories/SurveyTextArea.stories.tsx
@@ -9,4 +9,6 @@ export default {
 const Template = (args) => <SurveyTextArea {...args} />;
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  defaultValue: '제목 없는 설문',
+};

--- a/src/stories/SurveyTextArea.stories.tsx
+++ b/src/stories/SurveyTextArea.stories.tsx
@@ -10,5 +10,6 @@ const Template = (args) => <SurveyTextArea {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
+  placeholder: '여기에 입력하세요.',
   defaultValue: '제목 없는 설문',
 };


### PR DESCRIPTION
resolve #1 

이전 PR(#2)에서 구현했던 `fontsize`나 `background`는 사용처에서 다시 스타일을 덮어씌우면 그만이라 굳이 `props`로 줄 필요가 없다는 생각이 들어 뺐습니다.

구글 폼에서는 포커스가 세션 밖으로 나갈 때 아예 단순 라벨로 바뀌는 모습이 보이는데
이는 이 `TextArea`를 감싸는 컴포넌트가 하나 더 있어야 하는 걸까요?
아니면 `props`로 `mode`같은 걸 받아서 해당 컴포넌트에서 변해야 할까요...🤔

약간 범용성있는 컴포넌트가 될 것 같네요.
`SurveyTitle`, `Description`, `QuestionTitle` 등등이 해당 컴포넌트를 감싸는 형태로 나오게 되려나요??

제가 쓸데없이 너무 멀리까지 생각하려고 발버둥 치는 걸지도 모르겠네요. 😭
아직 처음이라 제가 감을 좀 많이 못잡고 있는 것 같아요. 많은 도움 부탁드립니다 ㅠㅠ